### PR TITLE
Server side friendly

### DIFF
--- a/tasks.ts
+++ b/tasks.ts
@@ -28,6 +28,8 @@ type TaskHandler = (tasks: Task[], dispatch: Dispatch) => void;
  * Implementation
  */
 const TASK_TYPE_TO_HANDLER = Symbol('TASK_TYPE_TO_HANDLER');
+const CACHED_PROMISE = Promise.resolve();
+const makeDispatchAsync = dispatch => action => CACHED_PROMISE.then(() => dispatch(action));
 
 let tasks : Task[] = [];
 
@@ -56,7 +58,7 @@ export const taskMiddleware = store => next => action => {
   }
 
   next(action);
-  const dispatch = store.dispatch;
+  const dispatch = makeDispatchAsync(store.dispatch);
 
   if (tasks.length > 0) {
 

--- a/tasks.ts
+++ b/tasks.ts
@@ -54,7 +54,8 @@ export const taskMiddleware = store => next => action => {
   if (tasks.length > 0) {
     throw lastWithTaskCall;
   }
-  const returnValue = next(action);
+
+  next(action);
   const dispatch = store.dispatch;
 
   if (tasks.length > 0) {
@@ -75,13 +76,15 @@ export const taskMiddleware = store => next => action => {
       }
     });
 
-    taskHandlers.forEach((tasks, handler) => handler(tasks, dispatch));
+    const out = [];
+    taskHandlers.forEach((tasks, handler) => out.push(handler(tasks, dispatch)));
 
     tasks = [];
     lastWithTaskCall = null;
+    return Promise.all(out);
   }
 
-  return returnValue;
+  return Promise.resolve(null);
 };
 
 /*

--- a/tasks.ts
+++ b/tasks.ts
@@ -54,7 +54,9 @@ export function makeTaskType(type: TaskType, handler: TaskHandler): TaskType {
  */
 export const taskMiddleware = store => next => action => {
   if (tasks.length > 0) {
-    throw lastWithTaskCall;
+    const err = lastWithTaskCall;
+    lastWithTaskCall = null;
+    throw err;
   }
 
   next(action);

--- a/test/task.spec.ts
+++ b/test/task.spec.ts
@@ -2,27 +2,61 @@ import test from 'ava';
 import {spy} from 'sinon';
 import {createStore, applyMiddleware} from 'redux';
 
-import {taskMiddleware, withTask, makeTaskType, drainTasksForTesting} from '../tasks';
+import {
+  taskMiddleware,
+  withTask,
+  makeTaskType,
+  drainTasksForTesting
+} from '../tasks';
 
-function XHR_TASK(payload) {
-  return {type: XHR_TASK, payload};
-}
+// tasks
+const XHR_TASK = payload => ({type: XHR_TASK, payload});
 const xhrHandlerSpy = spy();
 makeTaskType(XHR_TASK, xhrHandlerSpy);
 
-function ADD(amount) {
-  return {type: ADD, payload: {amount}};
-}
+// sync set task
+const SET_TASK_SYNC = payload => ({type: SET_TASK_SYNC, payload});
+makeTaskType(SET_TASK_SYNC, (tasks, dispatch) => {
+  tasks.forEach(task => {
+    dispatch(SET_SUCCESS(task.payload));
+  });
+});
 
-function BAD() {
-  return {type: BAD, payload: {}};
-}
+// async set task
+const SET_TASK_ASYNC = payload => ({type: SET_TASK_ASYNC, payload});
+makeTaskType(SET_TASK_ASYNC, (tasks, dispatch) => {
+  return Promise.all(
+    tasks.map(task =>
+      new Promise(resolve => {
+        setTimeout(() => {
+          dispatch(SET_SUCCESS(task.payload));
+          resolve();
+        }, 1E3);
+      })
+    )
+  );
+});
+
+// action creators
+const ADD = payload => ({type: ADD, payload});
+const SET_SYNC = payload => ({type: SET_SYNC, payload});
+const SET_ASYNC = payload => ({type: SET_ASYNC, payload});
+const SET_SUCCESS = payload => ({type: SET_SUCCESS, payload});
+const BAD = () => ({type: BAD, payload: {}});
 
 const reducer = (state = 0, action) => {
+  const {payload} = action;
+
   switch (action.type) {
   case ADD:
-    const newAmount = state + action.payload.amount;
-    return withTask(newAmount, [XHR_TASK({value: newAmount})]);
+    const newAmount = state + payload;
+    return withTask(newAmount, [XHR_TASK(newAmount)]);
+  case SET_SYNC:
+    return withTask(state, [SET_TASK_SYNC(payload)]);
+  case SET_ASYNC:
+    return withTask(state, [SET_TASK_ASYNC(payload)]);
+  case SET_SUCCESS:
+    return payload;
   case BAD:
     return withTask(state, BAD());
   default:
@@ -30,21 +64,18 @@ const reducer = (state = 0, action) => {
   }
 };
 
-function withHelpers(testFn) {
+const withHelpers = testFn => {
   const store = createStore(reducer, applyMiddleware(taskMiddleware));
-
-  return function testDelegate(t) {
-    return testFn({t, store});
-  };
+  return t => testFn({t, store});
 }
 
 test('Task middleware runs handlers', withHelpers(({t, store}) => {
   store.dispatch(ADD(3));
-  t.deepEqual(xhrHandlerSpy.args[0][0], [XHR_TASK({value: 3})]);
-  t.deepEqual(store.getState(), 3);
+  t.deepEqual(xhrHandlerSpy.args[0][0], [XHR_TASK(3)]);
+  t.is(store.getState(), 3);
 
   // the middleware should consume all of the tasks
-  let tasks = drainTasksForTesting();
+  const tasks = drainTasksForTesting();
   t.deepEqual(tasks, []);
 }));
 
@@ -54,19 +85,64 @@ test('Task middleware throws when task not created properly', withHelpers(({t, s
 }));
 
 test('Task middleware throws when tasks were added incorrectly', withHelpers(({t, store}) => {
-  function incorrectTaskAdd() {
-    withTask(null, XHR_TASK('test123'));
-  }
+
+  const incorrectTaskAdd = () => withTask(null, XHR_TASK('test123'));
+
   incorrectTaskAdd();
   t.throws(() => store.dispatch(ADD(3)), `Tasks should not be added outside of reducers.`);
 
   drainTasksForTesting();
   let stack = '';
+
   try {
     incorrectTaskAdd();
     store.dispatch(ADD(3));
   } catch (e) {
     stack = e.stack;
   }
+
   t.regex(stack, /incorrectTaskAdd/, 'Error includes stack of the first incorrect task usage');
+
+  drainTasksForTesting();
+
+}));
+
+test.cb('Task middleware works with sync task handler', withHelpers(({t, store }) => {
+
+  t.plan(3);
+
+  t.is(store.getState(), 0);
+  store.dispatch(SET_SYNC(42));
+
+  // Fake tick to wait for the dispatchAsync to be finished
+  setTimeout(() => {
+    t.is(store.getState(), 42);
+    t.end();
+  });
+
+  const tasks = drainTasksForTesting();
+  t.deepEqual(tasks, []);
+
+}));
+
+test.cb('Task middleware works with async task handler', withHelpers(({t, store}) => {
+
+  t.plan(4);
+
+  t.is(store.getState(), 0);
+  store.dispatch(SET_ASYNC(43));
+
+  setTimeout(() => {
+    t.is(store.getState(), 0);
+  }, 500);
+
+  // After a ~1E3 delay, the promise should have been resolved and have updated our state
+  setTimeout(() => {
+    t.is(store.getState(), 43);
+    t.end();
+  }, 1E3 + 1);
+
+  const tasks = drainTasksForTesting();
+  t.deepEqual(tasks, []);
+
 }));


### PR DESCRIPTION
By returning the promise of all our `taskHandlers` return values in the middleware, we can now dispatch actions triggering tasks on the server and wait for them to finish before sending back the response to the client.

Following this, we were unable to create synchronous handlers, thus the wrapping of the dispatch in a cached promise to fake asynchronicity.

I can replace the task handler example to reflect this, or maybe add it as an alternative in a comment?
