### PR TITLE
Feat: magic react 🙀

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -11,5 +11,5 @@ the tests. Developing a testing strategy (what do I unit test? what do I integra
 more on your problem domain than on these techniques.
 
 This is example also shows a recommended file and directory layout.
-Components, state, and reducers are collocted in the same file.
+Components, state, and reducers are collocated in the same file.
 For larger apps, you could instead create a directory and a single file for each of these.

--- a/example/list.tsx
+++ b/example/list.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from '../src/react';
 import {withTask} from '../src/tasks';
 
 import {XHR_TASK} from './tasks/xhr';
@@ -100,16 +100,16 @@ export const ListComponent = ({items, error, inputValue, isLoading, dispatch}) =
       <li key={index}>{item}</li>)}
     </ul>
     <input
-      onChange={(event) => dispatch(CHANGE_INPUT(event.target.value))}
+      onChange={(event) => CHANGE_INPUT(event.target.value)}
       value={inputValue} />
     <button
       id="add-item"
-      onClick={() => dispatch(ADD_ITEM())}
+      onClick={ADD_ITEM}
       disabled={isLoading}>
       Add item</button>
     <button
       id="add-item-eager"
-      onClick={() => dispatch(ADD_ITEM_EAGER())}
+      onClick={ADD_ITEM_EAGER}
       disabled={isLoading}>
       Add eager item</button>
   </div>

--- a/example/main.tsx
+++ b/example/main.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import {render} from 'react-dom';
+import React, {render} from '../src/react';
 import {createStore, applyMiddleware} from 'redux';
 import {connect, Provider} from 'react-redux';
 import {taskMiddleware} from '../src/tasks';
@@ -20,5 +19,6 @@ render(
   <Provider store={store}>
     <ConnectedApp />
   </Provider>,
-  window.document.getElementById('app-container')
+  window.document.getElementById('app-container'),
+  action => store.dispatch(action)
 );

--- a/example/test/integration/list.spec.tsx
+++ b/example/test/integration/list.spec.tsx
@@ -1,5 +1,5 @@
 import test from 'ava';
-import * as React from 'react';
+import React, {withDispatch} from '../../../src/react';
 import {mount} from 'enzyme';
 import {createStore} from 'redux';
 import {connect, Provider} from 'react-redux';
@@ -76,7 +76,7 @@ function withFixtures(doSpec) {
 
   const wrapper = mount(
     <Provider store={store}>
-      <ConnectedApp />
+      {withDispatch(store.dispatch, <ConnectedApp />)}
     </Provider>
   );
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon": "^1.17.4",
     "split": "^1.0.0",
     "through2": "^2.0.1",
-    "ts-loader": "^0.8.2",
+    "ts-loader": "^1.3.3",
     "typescript": "^2.2.0-dev.20161118",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -12,6 +12,7 @@ type Handler<S> = (state: S, payload: any, ...extra: any[]) => S;
 type Handlers<S> = {[action: string]: Handler<S>};
 
 const ACTION_CREATOR = Symbol('ACTION_CREATOR');
+const ACTION_MARKER = Symbol('ACTION_MARKER');
 const DEFAULT_ACTION_NAME = 'ACTION';
 const FN_NAME_CONFIGURABLE = Object.getOwnPropertyDescriptor(() => {}, 'name').configurable;
 
@@ -26,7 +27,7 @@ const FN_NAME_CONFIGURABLE = Object.getOwnPropertyDescriptor(() => {}, 'name').c
  * ```
  */
 export function createAction(name = DEFAULT_ACTION_NAME): ActionCreator {
-  const action = (payload = {}) => ({type: action, payload});
+  const action = (payload = {}) => ({type: action, payload, [ACTION_MARKER]: true});
 
   const uniqueSymbol = Symbol(name);
 
@@ -43,6 +44,10 @@ export function createAction(name = DEFAULT_ACTION_NAME): ActionCreator {
   action[ACTION_CREATOR] = true;
 
   return action;
+}
+
+export function isAction(maybeAction: any): boolean {
+  return Boolean(maybeAction[ACTION_MARKER]);
 }
 
 /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from './routing';
 export * from './subscriptions';
 export * from './tasks';
 export * from './test-utils';
+export * from './react';

--- a/src/react/index.html
+++ b/src/react/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example</title>
+  </head>
+  <body>
+    <div id="app-container"></div>
+    <script src="./main.bundle.js"></script>
+  </body>
+</html>

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,0 +1,3 @@
+export * from './react';
+import React from './react';
+export default React;

--- a/src/react/main.tsx
+++ b/src/react/main.tsx
@@ -1,0 +1,22 @@
+import React, {render, mapDispatch} from './react';
+
+function PARENT_ACTION(action) {
+  return {type: PARENT_ACTION, payload: action};
+}
+
+function GRAND_PARENT_ACTION(action) {
+  return {type: GRAND_PARENT_ACTION, payload: action};
+}
+
+render(
+  <div>
+    hi <a href="#" onClick={() => ({type: 'a', payload: 'b'})}>yo</a>
+
+    {mapDispatch(GRAND_PARENT_ACTION, (<div>
+      yo {mapDispatch(PARENT_ACTION,
+        (<a href="#" onClick={() => ({type: 'a', payload: 'b'})}>yo</a>))}
+    </div>))}
+  </div>,
+  window.document.getElementById('app-container'),
+  (args) => console.log('test', args)
+);

--- a/src/react/react.tsx
+++ b/src/react/react.tsx
@@ -1,0 +1,125 @@
+import * as RealReact from 'react';
+import {
+  Component, ReactElement, PropTypes, Children, createElement as realCreateElement
+} from 'react';
+
+import {render as realRender} from 'react-dom';
+// import {isAction} from '../actions';
+
+function isAction (maybeAction): boolean {
+  return Boolean(maybeAction.type);
+}
+
+/*
+ * We wrap React's create element to give us an event bus.
+ * This lets us eliminate the need for `mapDispatchToProps` or
+ * calling `connect` anywhere but at the application root.
+ *
+ * This has exactly the same function signature as `React.createElement`.
+ * See: https://facebook.github.io/react/docs/react-api.html#createelement
+ */
+const createElement = (type, props, ...children) => {
+  if (!props || typeof props !== 'object') {
+    return realCreateElement(type, props, ...children);
+  }
+
+  const child = (unwrapped, {dispatch}) => {
+    const props = wrapProps(unwrapped, dispatch);
+    return realCreateElement(type, props, ...unwrapped.children);
+  };
+
+  (child as any).contextTypes = {
+    dispatch: RealReact.PropTypes.func
+  };
+
+  return realCreateElement(child, props, ...children);
+};
+
+/*
+ * Given a map of props:
+ * `{ onClick: () => 'hi', label: 'bar' }`
+ * And a `dispatch` function, wrap all functions that might be event handlers:
+ * `{ onClick: () => (dispatch('hi'), 'hi'), label: 'bar' }`
+ */
+function wrapProps(props, dispatch) {
+  return Object.keys(props).reduce((newProps, name) => {
+    const prop = props[name];
+    newProps[name] = (typeof prop === 'function') ?
+      wrapEventHandler(prop, dispatch) :
+      prop;
+    return newProps;
+  }, {});
+}
+
+function wrapEventHandler(fn, dispatch) {
+  return (...args) => {
+    const result = fn(...args);
+    if (isAction(result)) {
+      dispatch(result);
+    }
+    return result;
+  };
+}
+
+export const React = {...RealReact, createElement};
+export default React;
+
+/*
+ *
+ */
+
+const CONTEXT_WITH_DISPATCH = {
+  dispatch: PropTypes.func
+};
+
+type DispatchFn = (...args: any[]) => void;
+
+export function withDispatch(dispatch, childElement) {
+  class Dispatch extends Component<{children: ReactElement<any>}, any> {
+    static childContextTypes = CONTEXT_WITH_DISPATCH;
+
+    getChildContext() {
+      return {dispatch};
+    }
+
+    render() {
+      const {children} = this.props;
+      return (children as any).length > 1 ? (<div>{children}</div>) : children;
+    }
+  }
+
+  return realCreateElement(Dispatch, null, childElement);
+}
+
+/*
+ * Takes a fn and a react element, returns a wrapped react element that
+ * composes over `fn` before calling dispatch
+ */
+export function mapDispatch(fn: Function, childElement: ReactElement<any>) {
+  class MapDispatch extends Component<{children: ReactElement<any>}, any> {
+    static childContextTypes = CONTEXT_WITH_DISPATCH
+    static contextTypes = CONTEXT_WITH_DISPATCH;
+
+    getChildContext() {
+      const {dispatch} = this.context as any;
+      return {
+        dispatch: (action) => dispatch(fn(action))
+      };
+    }
+
+    render() {
+      const {children} = this.props;
+      return (children as any).length > 1 ? (<div>{children}</div>) : children;
+    }
+  }
+
+  return (<MapDispatch>{childElement}</MapDispatch>);
+}
+
+/*
+ * Just like React's render, except that it also takes a `dispatch` function.
+ * Whenever an event handler returns an action, dispatch is called with that action.
+ */
+export function render(component, container, dispatch) {
+  return realRender(withDispatch(dispatch, component), container);
+}

--- a/test/actions.spec.ts
+++ b/test/actions.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {spy, stub} from 'sinon';
 
-import {handleActions, laxHandleActions, createAction} from '../src/actions';
+import {handleActions, laxHandleActions, createAction, isAction} from '../src/actions';
 
 const MY_ACTION = createAction();
 
@@ -121,4 +121,9 @@ test('laxHandleActions reducer passes extra params to handler', (t) => {
   reducer({}, MY_ACTION(123), 'extra1', {extra: 2});
 
   t.deepEqual(handler.firstCall.args, [{}, 123, 'extra1', {extra: 2}]);
+});
+
+test('isAction returns true only for actions from createAction', (t) => {
+  t.true(isAction(createAction('TEST')()));
+  t.false(isAction({type: 'NOPE', payload: 'uh-uh'}));
 });


### PR DESCRIPTION
"magic react" is a bad name.

This lets you bootstrap a react app with an event bus. It makes single dispatch less clumsy, because you don't need something like `mapDispatchToProps`. Any action you return from an event handler is dispatched.

Needs tests, and an update to the example app to use it.