### PR TITLE
Feat(tasks): Task.all, Task.map, and Task.bimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,9 @@ import { makeTaskType } from 'react-palm'
 
 const DELAY = ({ action, time }) => ({ type: DELAY, action, time })
 
-makeTaskType(XHR, (tasks, dispatch) =>
-  Promise.all(
-    tasks.map(task =>
-      new Promise(resolve => setTimeout(resolve, task.time))
-        .then(() => dispatch(task.action))
-    )
-  )
+makeTaskType(XHR, ({time, success}) =>
+  (new Promise(resolve => setTimeout(resolve, task.time)))
+    .then(() => success())
 )
 ```
 
@@ -64,7 +60,7 @@ The usage of thus task in the reducer could be something like this.
 
 ```javascript
 import { withTask } from 'react-palm'
-import { handleActions, createAction } from 'redux-actions'
+import { handleActions, createAction } from 'react-palm/actions'
 
 import DELAY from './tasks/delay'
 

--- a/example/tasks/xhr.ts
+++ b/example/tasks/xhr.ts
@@ -27,9 +27,8 @@ export interface XhrTaskOptions {
 export const XHR_TASK = ({payload, error, success}: XhrTaskOptions) =>
   ({type: XHR_TASK, payload, error, success});
 
-makeTaskType(XHR_TASK, (tasks: XhrTask[], dispatch) => {
-  tasks.forEach(task => setTimeout(() => {
-    const action = Math.random() > .3 ? task.success({}, 0) : task.error('Opps', 404);
-    dispatch(action);
-  }, 500));
+makeTaskType(XHR_TASK, (task: XhrTask) => {
+  setTimeout(() => {
+    Math.random() > .3 ? task.success({}, 0) : task.error('Opps', 404);
+  }, 500)
 });

--- a/src/history/task.ts
+++ b/src/history/task.ts
@@ -14,16 +14,10 @@ export const REPLACE_TASK = (url: string): LocationTask =>
 
 // The last task should be prevalent over all the other ones.
 
-makeTaskType(HISTORY_PUSH_TASK, (tasks: LocationTask[], dispatch) => {
-  if (tasks.length) {
-    const {url} = tasks[tasks.length - 1];
-    getHistory().push(url);
-  }
+makeTaskType(HISTORY_PUSH_TASK, (task: LocationTask) => {
+  getHistory().push(task.url);
 });
 
-makeTaskType(REPLACE_TASK, (tasks: LocationTask[], dispatch) => {
-  if (tasks.length) {
-    const {url} = tasks[tasks.length - 1];
-    getHistory().replace(url);
-  }
+makeTaskType(REPLACE_TASK, (task: LocationTask) => {
+  getHistory().replace(task.url);
 });


### PR DESCRIPTION
Breaking Change:

Task Handlers previously took an array of tasks, and a dispatch.
Now they recieve a task delegate, where `.success()` and `.error()`
are wrapped in the dispatch call by the middleware.

Need to do some more work on teasing apart a task definition from
a task execution. Ideally, execution should be opaque to users,
but we still need some way to provide action creators.

Closes #6