### PR TITLE
Refactor: Log instead of throwing

### DIFF
--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -135,7 +135,7 @@ export const taskMiddleware = store => next => action => {
   if (!module.hot && enableStackCapture && tasks.length > 0) {
     const err = lastWithTaskCall;
     lastWithTaskCall = null;
-    throw err;
+    console.error(err);
   }
 
   next(action);


### PR DESCRIPTION
Related to #18.

The stack capturing should be an indication of an error, not creating a way for your app to break in production where hot reload is not available.

*Will fix the tests after discussions.* 😛 